### PR TITLE
Remove CloudDeployment flag from Helm charts.

### DIFF
--- a/tip-wlan/charts/opensync-gw-cloud/templates/deployment.yaml
+++ b/tip-wlan/charts/opensync-gw-cloud/templates/deployment.yaml
@@ -4,7 +4,6 @@
 {{- $mqtt := include "mqtt.service" . -}}
 {{- $ns := include "common.namespace" . -}}
 {{- $file_store_path := include "filestore.dir.name" . -}}
-{{- $cloudeployment := .Values.global.isCloudDeployment -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,11 +72,6 @@ spec:
           - sh
           - -c
           - |
-            if [ {{ $cloudeployment }} = false ]
-            then            
-              echo "151.101.112.249 dl-cdn.alpinelinux.org" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi
             apk add curl
             url=https://{{ $icc }}/ping
             counter=0
@@ -105,11 +99,6 @@ spec:
           - sh
           - -c
           - |
-            if [ {{ $cloudeployment }} = false ]
-            then          
-              echo "151.101.112.249 dl-cdn.alpinelinux.org" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi
             apk add curl
             url=https://{{ $prov }}/ping
             counter=0
@@ -136,11 +125,6 @@ spec:
           - sh
           - -c
           - |
-            if [ {{ $cloudeployment }} = false ]
-            then          
-              echo "151.101.112.249 dl-cdn.alpinelinux.org" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi
             apk add curl
             url=https://{{ $ssc }}/ping
             counter=0

--- a/tip-wlan/charts/wlan-integrated-cloud-component-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-integrated-cloud-component-service/templates/deployment.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.global.integratedDeployment }}
 {{- $pg := include "postgresql.service" . -}}
 {{- $ns := include "common.namespace" . -}}
-{{- $cloudeployment := .Values.global.isCloudDeployment -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,15 +54,6 @@ spec:
           - sh
           - -c
           - |
-            if [ {{ $cloudeployment }} = false ]
-            then          
-              echo "151.101.112.249 dl-cdn.alpinelinux.org" >> /etc/hosts
-              echo "34.215.47.158 tip-tip-wlan-cloud-docker-repo.jfrog.io" >> /etc/hosts
-              echo "151.101.128.204 security.debian.org" >> /etc/hosts
-              echo "151.101.126.133 deb.debian.org" >> /etc/hosts
-              echo "147.75.85.69 apt.postgresql.org" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi
             apt update
             apt -y install curl
             echo "***** Fetching cloud-sdk-schema-postgresql.sql from JFrog *****"

--- a/tip-wlan/charts/wlan-port-forwarding-gateway-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-port-forwarding-gateway-service/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- $cloudeployment := .Values.global.isCloudDeployment -}}
 {{- $opensyncgw := include "opensyncgw.service" . -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,11 +29,6 @@ spec:
           - sh
           - -c
           - |
-            if [ {{ $cloudeployment }} = false ]
-            then          
-              echo "151.101.112.249 dl-cdn.alpinelinux.org" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi
             apk add curl
             url=https://{{ $opensyncgw }}/ping
             counter=0

--- a/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
@@ -1,6 +1,5 @@
 {{- $pg := include "postgresql.service" . -}}
 {{- $ns := include "common.namespace" . -}}
-{{- $cloudeployment := .Values.global.isCloudDeployment -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,16 +56,7 @@ spec:
           command:
           - sh
           - -c
-          - |
-            if [ {{ $cloudeployment }} = false ]
-            then
-              echo "151.101.2.133 dl-cdn.alpinelinux.org" >> /etc/hosts
-              echo "52.35.62.28 tip-tip-wlan-cloud-docker-repo.jfrog.io" >> /etc/hosts
-              echo "151.101.192.204 security.debian.org" >> /etc/hosts
-              echo "199.232.38.133 deb.debian.org" >> /etc/hosts
-              echo "147.75.85.69 apt.postgresql.org" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi            
+          - |      
             apt update
             apt -y install curl
             echo "***** Fetching latest cloud-sdk-schema-postgresql for DB and Tables sql from JFrog *****"

--- a/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
@@ -1,7 +1,6 @@
 {{- $kafka := include "kafka.service" . -}}
 {{- $cassandra := include "cassandra.service" . -}}
 {{- $ns := include "common.namespace" . -}}
-{{- $cloudeployment := .Values.global.isCloudDeployment -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,13 +52,6 @@ spec:
           - sh
           - -c
           - |
-            if [ {{ $cloudeployment }} = false ]
-            then
-              echo "52.35.62.28 tip-tip-wlan-cloud-docker-repo.jfrog.io" >> /etc/hosts
-              echo "91.189.88.152 security.ubuntu.com" >> /etc/hosts
-              echo "91.189.88.142 archive.ubuntu.com" >> /etc/hosts
-              echo "Added name-resolution for local deployments"
-            fi
             apt update
             apt -y install curl
             echo "***** Fetching cloud-sdk-schema-cassandra.cql from JFrog *****"

--- a/tip-wlan/resources/environments/dev-integrated.yaml
+++ b/tip-wlan/resources/environments/dev-integrated.yaml
@@ -30,8 +30,6 @@ global:
   # Integrated Deployment which deploys Prov Service, Portal Service and 
   # SSC Service in a single docker image 
   integratedDeployment: true
-  # Is the Cluster deployed in Cloud
-  isCloudDeployment: false
 # Annotations for namespace
 annotations: {
     "helm.sh/resource-policy": keep

--- a/tip-wlan/resources/environments/dev-no-gluster.yaml
+++ b/tip-wlan/resources/environments/dev-no-gluster.yaml
@@ -26,9 +26,6 @@ global:
   # flag to enable debugging - application support required
   debugEnabled: true
 
-  # Is the Cluster deployed in Cloud
-  isCloudDeployment: false
-
 # Annotations for namespace
 annotations: {
     "helm.sh/resource-policy": keep

--- a/tip-wlan/resources/environments/dev.yaml
+++ b/tip-wlan/resources/environments/dev.yaml
@@ -28,9 +28,6 @@ global:
   # flag to enable debugging - application support required
   debugEnabled: true
 
-  # Is the Cluster deployed in Cloud
-  isCloudDeployment: false
-
 # Annotations for namespace
 annotations: {
     "helm.sh/resource-policy": keep
@@ -82,6 +79,10 @@ wlan-prov-service:
     schema_repo:
       username: tip-read
       password: tip-read
+    postgres:
+      singleDataSourceUsername: tip_user
+      singleDataSourcePassword: tip_password
+      singleDataSourceSslKeyPassword: mypassword
 wlan-ssc-service:
   enabled: true
   creds:
@@ -127,6 +128,10 @@ kafka:
   persistence:
     enabled: true
     storageClass: "glusterfs-storage"
+  creds:
+    sslKeystorePassword: mypassword
+    sslTruststorePassword: mypassword
+    sslKeyPassword: mypassword
 cassandra:
   enabled: true
   cluster:
@@ -139,6 +144,9 @@ cassandra:
   persistence:
     enabled: true
     storageClass: "glusterfs-storage"
+  creds:
+    sslKeystorePassword: mypassword
+    sslTruststorePassword: mypassword
 postgresql:
   enabled: true
   postgresqlPassword: postgres
@@ -153,3 +161,7 @@ postgresql:
   persistence:
     enabled: true
     storageClass: "glusterfs-storage"
+  readinessProbe:
+    initialDelaySeconds: 30
+  livenessProbe:
+    initialDelaySeconds: 30

--- a/tip-wlan/resources/environments/disable-allcharts.yaml
+++ b/tip-wlan/resources/environments/disable-allcharts.yaml
@@ -30,9 +30,6 @@ global:
   # flag to enable debugging - application support required
   debugEnabled: true
 
-  # Is the Cluster deployed in Cloud
-  isCloudDeployment: false
-
 createReleaseNamespace: false
 
 createDockerRegistrySecret: false

--- a/tip-wlan/values.yaml
+++ b/tip-wlan/values.yaml
@@ -34,9 +34,6 @@ global:
   # SSC Service in a single docker image 
   integratedDeployment: false
 
-  # Is the Cluster deployed in Cloud
-  isCloudDeployment: true
-
   testingEnabled: false
 
   testingTimestamp: 


### PR DESCRIPTION
Not needed if pods(running in local env) can reach Jfrog to retrieve schema.