### PR TITLE
WIFI-991: alb ingress

### DIFF
--- a/tip-wlan/charts/nginx-ingress-controller/templates/controller-configmap.yaml
+++ b/tip-wlan/charts/nginx-ingress-controller/templates/controller-configmap.yaml
@@ -8,4 +8,3 @@ metadata:
 data:
     external-status-address: {{ .Values.controller.config.externalStatusAddress }}
     client-max-body-size: {{ .Values.controller.config.clientMaxBodySize }}
-    map-hash-bucket-size: "64"

--- a/tip-wlan/charts/nginx-ingress-controller/templates/controller-configmap.yaml
+++ b/tip-wlan/charts/nginx-ingress-controller/templates/controller-configmap.yaml
@@ -8,3 +8,4 @@ metadata:
 data:
     external-status-address: {{ .Values.controller.config.externalStatusAddress }}
     client-max-body-size: {{ .Values.controller.config.clientMaxBodySize }}
+    map-hash-bucket-size: "64"

--- a/tip-wlan/charts/opensync-gw-cloud/templates/service.yaml
+++ b/tip-wlan/charts/opensync-gw-cloud/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "common.namespace" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/tip-wlan/charts/opensync-gw-cloud/values.yaml
+++ b/tip-wlan/charts/opensync-gw-cloud/values.yaml
@@ -77,6 +77,7 @@ service:
   port5: 5005
   name5: debug
   nodePort5: 26
+  annotations: {}
 
 persistence:
   enabled: false

--- a/tip-wlan/charts/opensync-mqtt-broker/templates/service.yaml
+++ b/tip-wlan/charts/opensync-mqtt-broker/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "common.namespace" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/tip-wlan/charts/opensync-mqtt-broker/values.yaml
+++ b/tip-wlan/charts/opensync-mqtt-broker/values.yaml
@@ -61,6 +61,7 @@ service:
   port2: 9001
   name2: debug
   nodePort2: 32
+  annotations: {}
 
 ingress:
   enabled: false

--- a/tip-wlan/charts/wlan-cloud-graphql-gw/templates/ingress.yaml
+++ b/tip-wlan/charts/wlan-cloud-graphql-gw/templates/ingress.yaml
@@ -32,6 +32,12 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+        {{- if $.Values.ingress.alb_https_redirect }}
+          - path: /*
+            backend:
+              serviceName: ssl-redirect
+              servicePort: use-annotation
+        {{- end }}
         {{- range .paths }}
           - path: {{ . }}
             backend:

--- a/tip-wlan/charts/wlan-cloud-graphql-gw/values.yaml
+++ b/tip-wlan/charts/wlan-cloud-graphql-gw/values.yaml
@@ -54,6 +54,7 @@ service:
 
 ingress:
   enabled: true
+  alb_https_redirect: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/tip-wlan/charts/wlan-cloud-static-portal/templates/ingress.yaml
+++ b/tip-wlan/charts/wlan-cloud-static-portal/templates/ingress.yaml
@@ -32,6 +32,12 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+        {{- if $.Values.ingress.alb_https_redirect }}
+          - path: /*
+            backend:
+              serviceName: ssl-redirect
+              servicePort: use-annotation
+        {{- end }}
         {{- range .paths }}
           - path: {{ . }}
             backend:

--- a/tip-wlan/charts/wlan-cloud-static-portal/templates/service.yaml
+++ b/tip-wlan/charts/wlan-cloud-static-portal/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "common.namespace" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/tip-wlan/charts/wlan-cloud-static-portal/values.yaml
+++ b/tip-wlan/charts/wlan-cloud-static-portal/values.yaml
@@ -50,6 +50,7 @@ service:
 
 ingress:
   enabled: true
+  alb_https_redirect: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/tip-wlan/charts/wlan-portal-service/templates/ingress.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/ingress.yaml
@@ -32,6 +32,12 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+        {{- if $.Values.ingress.alb_https_redirect }}
+          - path: /*
+            backend:
+              serviceName: ssl-redirect
+              servicePort: use-annotation
+        {{- end }}
         {{- range .paths }}
           - path: {{ . }}
             backend:

--- a/tip-wlan/charts/wlan-portal-service/templates/service.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "common.namespace" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,24 +16,15 @@ spec:
       targetPort: {{ .Values.service.port1 }}
       protocol: TCP
       name: {{ .Values.service.name1 }}
-      {{- if eq .Values.service.type "NodePort" }}
-      nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort1 }}
-      {{- end }}
     - port: {{ .Values.service.port2 }}
       targetPort: {{ .Values.service.port2 }}
       protocol: TCP
       name: {{ .Values.service.name2 }}
-      {{- if eq .Values.service.type "NodePort" }}
-      nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort2 }}
-      {{- end }}
     {{- if .Values.debug.enabled }}
     - port: {{ .Values.service.port3 }}
       targetPort: {{ .Values.service.port3 }}
       protocol: TCP
       name: {{ .Values.service.name3 }}
-      {{- if eq .Values.service.type "NodePort" }}
-      nodePort: {{ .Values.global.nodePortPrefix }}{{ .Values.service.nodePort3 }}
-      {{- end }}
     {{- end }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}

--- a/tip-wlan/charts/wlan-portal-service/templates/service.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/service.yaml
@@ -16,15 +16,24 @@ spec:
       targetPort: {{ .Values.service.port1 }}
       protocol: TCP
       name: {{ .Values.service.name1 }}
+      {{- if and .Values.service.nodePort_static (eq .Values.service.type "NodePort") }}
+      nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort1 }}
+      {{- end }}
     - port: {{ .Values.service.port2 }}
       targetPort: {{ .Values.service.port2 }}
       protocol: TCP
       name: {{ .Values.service.name2 }}
+      {{- if and .Values.service.nodePort_static (eq .Values.service.type "NodePort") }}
+      nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort2 }}
+      {{- end }}
     {{- if .Values.debug.enabled }}
     - port: {{ .Values.service.port3 }}
       targetPort: {{ .Values.service.port3 }}
       protocol: TCP
       name: {{ .Values.service.name3 }}
+      {{- if and .Values.service.nodePort_static (eq .Values.service.type "NodePort") }}
+      nodePort: {{ .Values.global.nodePortPrefix }}{{ .Values.service.nodePort3 }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}

--- a/tip-wlan/charts/wlan-portal-service/values.yaml
+++ b/tip-wlan/charts/wlan-portal-service/values.yaml
@@ -75,7 +75,7 @@ service:
   port3: 5006
   name3: debug
   nodePort3: 15
-  nodePort_static: false
+  nodePort_static: true
 
 ingress:
   enabled: false

--- a/tip-wlan/charts/wlan-portal-service/values.yaml
+++ b/tip-wlan/charts/wlan-portal-service/values.yaml
@@ -78,6 +78,7 @@ service:
 
 ingress:
   enabled: false
+  alb_https_redirect: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/tip-wlan/charts/wlan-portal-service/values.yaml
+++ b/tip-wlan/charts/wlan-portal-service/values.yaml
@@ -74,7 +74,8 @@ service:
   nodePort2: 52
   port3: 5006
   name3: debug
-  nodePort3: 15  
+  nodePort3: 15
+  nodePort_static: false
 
 ingress:
   enabled: false

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -64,6 +64,11 @@ opensync-mqtt-broker:
 wlan-cloud-graphql-gw:
   enabled: true
   ingress:
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/group.name: ui
+      alb.ingress.kubernetes.io/group.order: "2"
     enabled: true
     hosts:
     - host: wlan-graphql.testcluster.lab.wlan.tip.build    
@@ -76,7 +81,14 @@ wlan-cloud-static-portal:
   enabled: true
   env:
     graphql: https://wlan-graphql.testcluster.lab.wlan.tip.build
+  service:
+    type: NodePort
   ingress:
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/group.name: ui
+      alb.ingress.kubernetes.io/group.order: "1"
     hosts:
       - host: wlan-ui.testcluster.lab.wlan.tip.build
         paths: [

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -154,6 +154,10 @@ wlan-prov-service:
     schema_repo:
       username: tip-read
       password: tip-read
+    postgres:
+      singleDataSourceUsername: tip_user
+      singleDataSourcePassword: tip_password
+      singleDataSourceSslKeyPassword: mypassword
 wlan-ssc-service:
   enabled: true
   creds:
@@ -206,10 +210,10 @@ cassandra:
   resources:
     requests:
       cpu: 500m
-      memory: 4Gi
+      memory: 3800Mi
     limits:
       cpu: 1000m
-      memory: 4Gi
+      memory: 3800Mi
   creds:
     sslKeystorePassword: mypassword
     sslTruststorePassword: mypassword

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -47,6 +47,9 @@ common:
       efsDnsName: fs-49a5104c.efs.us-west-2.amazonaws.com
       storageClass: aws-efs  
 opensync-gw-cloud:
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
   enabled: true
   externalhostaddress:
     ovsdb: opensync-controller.testcluster.lab.wlan.tip.build
@@ -56,6 +59,9 @@ opensync-gw-cloud:
   filestore:
     url: "https://wlan-filestore.testcluster.lab.wlan.tip.build"
 opensync-mqtt-broker:
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
   enabled: true
   replicaCount: 1
   persistence:

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -50,11 +50,11 @@ opensync-gw-static:
   enabled: false
 common:
   efs-provisioner:
-    enabled: false
+    enabled: true
     provisioner:
       efsFileSystemId: fs-49a5104c
       awsRegion: us-west-2
-      efsDnsName: fs-49a5104c.efs.us-west-2.amazonaws.com
+      efsDnsName: fs-71d97384.efs.us-east-1.amazonaws.com
       storageClass: aws-efs
 opensync-gw-cloud:
   service:
@@ -122,8 +122,7 @@ wlan-portal-service:
   enabled: true
   persistence:
     enabled: true
-    storageClass: gp2
-    accessMode: ReadWriteOnce
+    storageClass: aws-efs
     filestoreSize: 10Gi
   tsp:
     host: wlan-portal-svc.testcluster.lab.wlan.tip.build

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -69,6 +69,8 @@ wlan-cloud-graphql-gw:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/group.name: ui
       alb.ingress.kubernetes.io/group.order: "2"
+      alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     enabled: true
     hosts:
     - host: wlan-graphql.testcluster.lab.wlan.tip.build    
@@ -89,6 +91,8 @@ wlan-cloud-static-portal:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/group.name: ui
       alb.ingress.kubernetes.io/group.order: "1"
+      alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     hosts:
       - host: wlan-ui.testcluster.lab.wlan.tip.build
         paths: [

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -89,8 +89,7 @@ wlan-cloud-graphql-gw:
   enabled: true
   ingress:
     annotations:
-    <<: *srv-https-annotations
-    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-cloud-graphql-gw
+      <<: *srv-https-annotations
     enabled: true
     alb_https_redirect: true
     hosts:
@@ -108,8 +107,8 @@ wlan-cloud-static-portal:
     type: NodePort
   ingress:
     annotations:
-    <<: *srv-https-annotations
-    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-cloud-static-portal
+      <<: *srv-https-annotations
+      alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-testcluster
     alb_https_redirect: true
     hosts:
       - host: wlan-ui.testcluster.lab.wlan.tip.build
@@ -138,7 +137,6 @@ wlan-portal-service:
       alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
       alb.ingress.kubernetes.io/healthcheck-port: traffic-port
       alb.ingress.kubernetes.io/healthcheck-path: /ping
-      alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-portal-service
     hosts:
       - host: wlan-portal-svc.testcluster.lab.wlan.tip.build
         paths: [

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -68,7 +68,6 @@ wlan-cloud-graphql-gw:
       kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/group.name: ui
-      alb.ingress.kubernetes.io/group.order: "2"
       alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     enabled: true
@@ -90,7 +89,6 @@ wlan-cloud-static-portal:
       kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/group.name: ui
-      alb.ingress.kubernetes.io/group.order: "1"
       alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     hosts:
@@ -107,6 +105,20 @@ wlan-portal-service:
     filestoreSize: 10Gi
   tsp:
     host: wlan-portal-service.testcluster.lab.wlan.tip.build
+  ingress:
+    enabled: true
+    tls: []
+    annotations:
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/group.name: ui
+      alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    hosts:
+      - host: wlan-portal-service.testcluster.lab.wlan.tip.build
+        paths: [
+           /
+          ]
 wlan-prov-service:
   enabled: true
   creds:

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -16,7 +16,7 @@ shared:
     srv-https-annotations: &srv-https-annotations
       kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/group.name: tip-wlan
+      alb.ingress.kubernetes.io/group.name: wlan-testcluster
       alb.ingress.kubernetes.io/certificate-arn: ""
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
       alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
@@ -55,11 +55,15 @@ common:
       efsFileSystemId: fs-49a5104c
       awsRegion: us-west-2
       efsDnsName: fs-49a5104c.efs.us-west-2.amazonaws.com
-      storageClass: aws-efs  
+      storageClass: aws-efs
 opensync-gw-cloud:
   service:
+    type: LoadBalancer
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+      external-dns.alpha.kubernetes.io/hostname: wlan-filestore.testcluster.lab.wlan.tip.build,opensync-controller.testcluster.lab.wlan.tip.build,opensync-redirector.testcluster.lab.wlan.tip.build
+      service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "alb-logs-tip-wlan-testcluster-xqgkeyjvjk"
+      service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "opensync-gw-cloud"
   enabled: true
   externalhostaddress:
     ovsdb: opensync-controller.testcluster.lab.wlan.tip.build
@@ -70,8 +74,12 @@ opensync-gw-cloud:
     url: "https://wlan-filestore.testcluster.lab.wlan.tip.build"
 opensync-mqtt-broker:
   service:
+    type: LoadBalancer
     annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+      external-dns.alpha.kubernetes.io/hostname: "opensync-mqtt-broker.testcluster.lab.wlan.tip.build"
+      service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "alb-logs-tip-wlan-testcluster-xqgkeyjvjk"
+      service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "opensync-mqtt-broker"
   enabled: true
   replicaCount: 1
   persistence:
@@ -80,13 +88,15 @@ opensync-mqtt-broker:
 wlan-cloud-graphql-gw:
   enabled: true
   ingress:
-    annotations: *srv-https-annotations
+    annotations:
+    <<: *srv-https-annotations
+    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-cloud-graphql-gw
     enabled: true
     alb_https_redirect: true
     hosts:
     - host: wlan-graphql.testcluster.lab.wlan.tip.build    
       paths: [
-        /
+        /*
         ]
   env:
     portalsvc: wlan-portal-svc.testcluster.lab.wlan.tip.build
@@ -97,14 +107,19 @@ wlan-cloud-static-portal:
   service:
     type: NodePort
   ingress:
-    annotations: *srv-https-annotations
+    annotations:
+    <<: *srv-https-annotations
+    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-cloud-static-portal
     alb_https_redirect: true
     hosts:
       - host: wlan-ui.testcluster.lab.wlan.tip.build
         paths: [
-           /
+           /*
           ]
 wlan-portal-service:
+  service:
+    type: NodePort
+    nodePort_static: false
   enabled: true
   persistence:
     enabled: true
@@ -112,16 +127,22 @@ wlan-portal-service:
     accessMode: ReadWriteOnce
     filestoreSize: 10Gi
   tsp:
-    host: wlan-portal-service.testcluster.lab.wlan.tip.build
+    host: wlan-portal-svc.testcluster.lab.wlan.tip.build
   ingress:
     enabled: true
     alb_https_redirect: true
     tls: []
-    annotations: *srv-https-annotations
+    annotations:
+      <<: *srv-https-annotations
+      alb.ingress.kubernetes.io/backend-protocol: HTTPS
+      alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
+      alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+      alb.ingress.kubernetes.io/healthcheck-path: /ping
+      alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=alb-logs-tip-wlan-testcluster-xqgkeyjvjk,access_logs.s3.prefix=wlan-portal-service
     hosts:
-      - host: wlan-portal-service.testcluster.lab.wlan.tip.build
+      - host: wlan-portal-svc.testcluster.lab.wlan.tip.build
         paths: [
-           /
+           /*
           ]
 wlan-prov-service:
   enabled: true

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -168,21 +168,6 @@ wlan-port-forwarding-gateway-service:
   externallyVisible:
     host: api.wlan.testcluster.lab.wlan.tip.build
     port: 30401
-nginx-ingress-controller:
-  enabled: true
-  controller:
-    nginxDebug: true
-    service:
-      type: LoadBalancer
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42
-        service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-        service.beta.kubernetes.io/aws-load-balancer-type: elb
-        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-      httpsPort:
-        targetPort: 80
-    config:
-      externalStatusAddress: "api.wlan.testcluster.lab.wlan.tip.build"
 zookeeper:
   enabled: true
   replicaCount: 1

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -11,6 +11,16 @@
 # These overrides will affect all helm charts (ie. applications)
 # that are listed below and are 'enabled'.
 #################################################################
+shared:
+  service:
+    srv-https-annotations: &srv-https-annotations
+      kubernetes.io/ingress.class: alb
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/group.name: tip-wlan
+      alb.ingress.kubernetes.io/certificate-arn: ""
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
+
 global:
   # Change to an unused port prefix range to prevent port conflicts
   # with other instances running within the same k8s cluster
@@ -70,13 +80,7 @@ opensync-mqtt-broker:
 wlan-cloud-graphql-gw:
   enabled: true
   ingress:
-    annotations:
-      kubernetes.io/ingress.class: alb
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/group.name: ui
-      alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
+    annotations: *srv-https-annotations
     enabled: true
     alb_https_redirect: true
     hosts:
@@ -93,13 +97,7 @@ wlan-cloud-static-portal:
   service:
     type: NodePort
   ingress:
-    annotations:
-      kubernetes.io/ingress.class: alb
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/group.name: ui
-      alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
+    annotations: *srv-https-annotations
     alb_https_redirect: true
     hosts:
       - host: wlan-ui.testcluster.lab.wlan.tip.build
@@ -119,13 +117,7 @@ wlan-portal-service:
     enabled: true
     alb_https_redirect: true
     tls: []
-    annotations:
-      kubernetes.io/ingress.class: alb
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/group.name: ui
-      alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
+    annotations: *srv-https-annotations
     hosts:
       - host: wlan-portal-service.testcluster.lab.wlan.tip.build
         paths: [

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -70,7 +70,9 @@ wlan-cloud-graphql-gw:
       alb.ingress.kubernetes.io/group.name: ui
       alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
     enabled: true
+    alb_https_redirect: true
     hosts:
     - host: wlan-graphql.testcluster.lab.wlan.tip.build    
       paths: [
@@ -91,6 +93,8 @@ wlan-cloud-static-portal:
       alb.ingress.kubernetes.io/group.name: ui
       alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
+    alb_https_redirect: true
     hosts:
       - host: wlan-ui.testcluster.lab.wlan.tip.build
         paths: [
@@ -107,6 +111,7 @@ wlan-portal-service:
     host: wlan-portal-service.testcluster.lab.wlan.tip.build
   ingress:
     enabled: true
+    alb_https_redirect: true
     tls: []
     annotations:
       kubernetes.io/ingress.class: alb
@@ -114,6 +119,7 @@ wlan-portal-service:
       alb.ingress.kubernetes.io/group.name: ui
       alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42"
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_302"}}'
     hosts:
       - host: wlan-portal-service.testcluster.lab.wlan.tip.build
         paths: [

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -19,22 +19,17 @@ global:
   nsPrefix: tip
   # image pull policy
   pullPolicy: Always
-
   repository: tip-tip-wlan-cloud-docker-repo.jfrog.io
   # override default mount path root directory
   # referenced by persistent volumes and log files
   persistence:
-
   # flag to enable debugging - application support required
   debugEnabled: true
-
 # Annotations for namespace
 annotations: {
     "helm.sh/resource-policy": keep
 }
-
 #createReleaseNamespace: false
-
 # Docker registry secret
 dockerRegistrySecret: ewoJImF1dGhzIjogewoJCSJ0aXAtdGlwLXdsYW4tY2xvdWQtZG9ja2VyLXJlcG8uamZyb2cuaW8iOiB7CgkJCSJhdXRoIjogImRHbHdMWEpsWVdRNmRHbHdMWEpsWVdRPSIKCQl9Cgl9LAoJIkh0dHBIZWFkZXJzIjogewoJCSJVc2VyLUFnZW50IjogIkRvY2tlci1DbGllbnQvMTkuMDMuOCAobGludXgpIgoJfQp9
 #################################################################
@@ -45,7 +40,7 @@ opensync-gw-static:
   enabled: false
 common:
   efs-provisioner:
-    enabled: true
+    enabled: false
     provisioner:
       efsFileSystemId: fs-49a5104c
       awsRegion: us-west-2
@@ -54,12 +49,12 @@ common:
 opensync-gw-cloud:
   enabled: true
   externalhostaddress:
-    ovsdb: opensync-controller.demo.lab.wlan.tip.build
-    mqtt: opensync-mqtt-broker.demo.lab.wlan.tip.build
+    ovsdb: opensync-controller.testcluster.lab.wlan.tip.build
+    mqtt: opensync-mqtt-broker.testcluster.lab.wlan.tip.build
   persistence:
     enabled: false
   filestore:
-    url: "https://wlan-filestore.demo.lab.wlan.tip.build"
+    url: "https://wlan-filestore.testcluster.lab.wlan.tip.build"
 opensync-mqtt-broker:
   enabled: true
   replicaCount: 1
@@ -68,15 +63,22 @@ opensync-mqtt-broker:
     storageClass: "gp2"
 wlan-cloud-graphql-gw:
   enabled: true
+  ingress:
+    enabled: true
+    hosts:
+    - host: wlan-graphql.testcluster.lab.wlan.tip.build    
+      paths: [
+        /
+        ]
   env:
-    portalsvc: wlan-portal-svc.demo.lab.wlan.tip.build
+    portalsvc: wlan-portal-svc.testcluster.lab.wlan.tip.build
 wlan-cloud-static-portal:
   enabled: true
   env:
-    graphql: https://wlan-graphql.demo.lab.wlan.tip.build
+    graphql: https://wlan-graphql.testcluster.lab.wlan.tip.build
   ingress:
     hosts:
-      - host: wlan-ui.demo.lab.wlan.tip.build
+      - host: wlan-ui.testcluster.lab.wlan.tip.build
         paths: [
            /
           ]
@@ -84,8 +86,11 @@ wlan-portal-service:
   enabled: true
   persistence:
     enabled: true
-    storageClass: aws-efs
+    storageClass: gp2
+    accessMode: ReadWriteOnce
     filestoreSize: 10Gi
+  tsp:
+    host: wlan-portal-service.testcluster.lab.wlan.tip.build
 wlan-prov-service:
   enabled: true
   creds:
@@ -121,13 +126,24 @@ wlan-port-forwarding-gateway-service:
   creds:
     websocketSessionTokenEncKey: MyToKeN0MyToKeN1
   externallyVisible:
-    host: api.wlan.demo.lab.wlan.tip.build
+    host: api.wlan.testcluster.lab.wlan.tip.build
     port: 30401
 nginx-ingress-controller:
   enabled: true
   controller:
+    nginxDebug: true
+    service:
+      type: LoadBalancer
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:289708231103:certificate/eeab0cc5-f6d1-4bf2-a125-9dbf10daed42
+        service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
+        service.beta.kubernetes.io/aws-load-balancer-type: elb
+        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      httpsPort:
+        targetPort: 80
     config:
-      externalStatusAddress: "api.wlan.demo.lab.wlan.tip.build"
+      map-hash-bucket-size: "64"
+  #     externalStatusAddress: "api.wlan.testcluster.lab.wlan.tip.build"
 zookeeper:
   enabled: true
   replicaCount: 1
@@ -140,6 +156,10 @@ kafka:
   persistence:
     enabled: true
     storageClass: "gp2"
+  creds:
+    sslKeystorePassword: mypassword
+    sslTruststorePassword: mypassword
+    sslKeyPassword: mypassword
 cassandra:
   enabled: true
   config:
@@ -155,6 +175,9 @@ cassandra:
     limits:
       cpu: 1000m
       memory: 4Gi
+  creds:
+    sslKeystorePassword: mypassword
+    sslTruststorePassword: mypassword
 postgresql:
   enabled: true
   postgresqlPassword: postgres

--- a/tip-wlan/resources/environments/dev-amazon-tip.yaml
+++ b/tip-wlan/resources/environments/dev-amazon-tip.yaml
@@ -142,8 +142,7 @@ nginx-ingress-controller:
       httpsPort:
         targetPort: 80
     config:
-      map-hash-bucket-size: "64"
-  #     externalStatusAddress: "api.wlan.testcluster.lab.wlan.tip.build"
+      externalStatusAddress: "api.wlan.testcluster.lab.wlan.tip.build"
 zookeeper:
   enabled: true
   replicaCount: 1
@@ -171,7 +170,7 @@ cassandra:
   resources:
     requests:
       cpu: 500m
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: 1000m
       memory: 4Gi


### PR DESCRIPTION
Installation:

```
helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=tip-wlan-testcluster --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::289708231103:role/tip-wlan-testcluster-alb-ingress"
```

- creates shared alb for all Ingress based services;
- creates dedicated nlb for each service;