### PR TITLE
WIFI-990: disable hardcoded NodePort for AWS deployments

### DIFF
--- a/tip-wlan/charts/common/templates/_ports.tpl
+++ b/tip-wlan/charts/common/templates/_ports.tpl
@@ -4,14 +4,17 @@
   */}}
 
 {{- define "container.dev.debugport" -}}
+  {{- if .Values.debug.enabled }}
   {{- range $index, $portid := .Values.debugPorts }}
   - name: debugport-{{ $index }}
     containerPort: {{ $portid }}
     protocol: TCP
   {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{- define "service.dev.debugport" -}}
+  {{- if .Values.debug.enabled }}
   {{- range $index, $portid := .Values.debugPorts }}
   - port: {{ $portid }}
     targetPort: {{ $portid }}
@@ -20,5 +23,6 @@
     {{- if eq $.Values.service.type "NodePort" }}
     nodePort: {{ $portid }}
     {{- end }}   
+  {{- end }}
   {{- end }}
 {{- end -}}

--- a/tip-wlan/charts/wlan-cloud-graphql-gw/templates/service.yaml
+++ b/tip-wlan/charts/wlan-cloud-graphql-gw/templates/service.yaml
@@ -12,6 +12,8 @@ spec:
       targetPort: {{ .Values.service.port }}
       protocol: TCP
       name: {{ .Values.service.name }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}

--- a/tip-wlan/charts/wlan-cloud-graphql-gw/values.yaml
+++ b/tip-wlan/charts/wlan-cloud-graphql-gw/values.yaml
@@ -51,6 +51,7 @@ service:
   port: 4000
   name: graphui
   nodePort: 23
+  nodePortStatic: true ## if true, nodePort ports are statically defined effectively prohibiting multiple deployments on the same cluster; if false, nodePort ports are chosen dynamically by k8s
 
 ingress:
   enabled: true

--- a/tip-wlan/charts/wlan-prov-service/templates/service.yaml
+++ b/tip-wlan/charts/wlan-prov-service/templates/service.yaml
@@ -12,14 +12,14 @@ spec:
       targetPort: {{ .Values.service.port1 }}
       protocol: TCP
       name: {{ .Values.service.name1 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort1 }}
       {{- end }}
     - port: {{ .Values.service.port2 }}
       targetPort: {{ .Values.service.port2 }}
       protocol: TCP
       name: {{ .Values.service.name2 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort2 }}
       {{- end }}
     {{- if .Values.debug.enabled }}
@@ -27,7 +27,7 @@ spec:
       targetPort: {{ .Values.service.port3 }}
       protocol: TCP
       name: {{ .Values.service.name3 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix }}{{ .Values.service.nodePort3 }}
       {{- end }}
     {{- end }}      

--- a/tip-wlan/charts/wlan-prov-service/values.yaml
+++ b/tip-wlan/charts/wlan-prov-service/values.yaml
@@ -86,6 +86,7 @@ service:
   name2: secondary-port
   port3: 5007
   name3: debug
+  nodePortStatic: true ## if true, nodePort ports are statically defined effectively prohibiting multiple deployments on the same cluster; if false, nodePort ports are chosen dynamically by k8s
 
 ingress:
   enabled: false

--- a/tip-wlan/charts/wlan-spc-service/templates/service.yaml
+++ b/tip-wlan/charts/wlan-spc-service/templates/service.yaml
@@ -12,14 +12,14 @@ spec:
       targetPort: {{ .Values.service.port1 }}
       protocol: TCP
       name: {{ .Values.service.name1 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort1 }}
       {{- end }}
     - port: {{ .Values.service.port2 }}
       targetPort: {{ .Values.service.port2 }}
       protocol: TCP
       name: {{ .Values.service.name2 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort2 }}
       {{- end }}
     {{- if .Values.debug.enabled }}
@@ -27,7 +27,7 @@ spec:
       targetPort: {{ .Values.service.port3 }}
       protocol: TCP
       name: {{ .Values.service.name3 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix }}{{ .Values.service.nodePort3 }}
       {{- end }}
     {{- end }}      

--- a/tip-wlan/charts/wlan-spc-service/values.yaml
+++ b/tip-wlan/charts/wlan-spc-service/values.yaml
@@ -70,6 +70,7 @@ service:
   name2: secondary-port
   port3: 5009
   name3: debug
+  nodePortStatic: true ## if true, nodePort ports are statically defined effectively prohibiting multiple deployments on the same cluster; if false, nodePort ports are chosen dynamically by k8s
 
 ingress:
   enabled: false

--- a/tip-wlan/charts/wlan-ssc-service/templates/service.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/service.yaml
@@ -12,14 +12,14 @@ spec:
       targetPort: {{ .Values.service.port1 }}
       protocol: TCP
       name: {{ .Values.service.name1 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort1 }}
       {{- end }}
     - port: {{ .Values.service.port2 }}
       targetPort: {{ .Values.service.port2 }}
       protocol: TCP
       name: {{ .Values.service.name2 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix | default .Values.nodePortPrefix }}{{ .Values.service.nodePort2 }}
       {{- end }}
     {{- if .Values.debug.enabled }}
@@ -27,7 +27,7 @@ spec:
       targetPort: {{ .Values.service.port3 }}
       protocol: TCP
       name: {{ .Values.service.name3 }}
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if and .Values.service.nodePortStatic (eq .Values.service.type "NodePort") }}
       nodePort: {{ .Values.global.nodePortPrefix }}{{ .Values.service.nodePort3 }}
       {{- end }}
     {{- end }}      

--- a/tip-wlan/charts/wlan-ssc-service/values.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/values.yaml
@@ -70,6 +70,7 @@ service:
   name2: secondary-port
   port3: 5008
   name3: debug
+  nodePortStatic: true ## if true, nodePort ports are statically defined effectively prohibiting multiple deployments on the same cluster; if false, nodePort ports are chosen dynamically by k8s
 
 ingress:
   enabled: false


### PR DESCRIPTION
Similar to https://github.com/Telecominfraproject/wlan-cloud-helm/pull/29, disabling static ports that would collide when more than one cloudsdk is deployed