### PR TITLE
WIFI-1199 fix cassandra headless hostname

### DIFF
--- a/tip-wlan/charts/cassandra/files/cqlshrc.tip-wlan
+++ b/tip-wlan/charts/cassandra/files/cqlshrc.tip-wlan
@@ -72,7 +72,7 @@ color = on
 [connection]
 
 ;; The host to connect to
-hostname = tip-wlan-cassandra-headless
+hostname = {{ include "cassandra.service" . }}
 
 ;; The port to connect to (9042 is the native protocol default)
 port = 9042

--- a/tip-wlan/charts/cassandra/templates/configmap.yaml
+++ b/tip-wlan/charts/cassandra/templates/configmap.yaml
@@ -5,3 +5,5 @@ metadata:
   namespace: {{ include "common.namespace" . }}
 data:
 {{ tpl (.Files.Glob "resources/config/*").AsConfig . | indent 2 }}
+  cqlshrc.tip-wlan: |
+  {{ tpl (.Files.Get "files/cqlshrc.tip-wlan") . | nindent 4 }}

--- a/tip-wlan/charts/cassandra/templates/headless-svc.yaml
+++ b/tip-wlan/charts/cassandra/templates/headless-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "common.fullname" . }}-headless
+  name: {{ include "cassandra.service" . }}
   namespace: {{ include "common.namespace" . }}
   labels: {{- include "common.labels" . | nindent 4 }}
   annotations: {{ include "cassandra.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}

--- a/tip-wlan/charts/cassandra/values.yaml
+++ b/tip-wlan/charts/cassandra/values.yaml
@@ -329,3 +329,6 @@ metrics:
 creds:
   sslKeystorePassword: DUMMY_PASSWORD
   sslTruststorePassword: DUMMY_PASSWORD
+
+cassandra:
+  url: cassandra-headless

--- a/tip-wlan/charts/wlan-ssc-service/files/cqlshrc.tip-wlan
+++ b/tip-wlan/charts/wlan-ssc-service/files/cqlshrc.tip-wlan
@@ -67,12 +67,10 @@ color = on
 ;; A version of CQL to use (this should almost never be set)
 ; version = 3.2.1
 
-
-
 [connection]
 
 ;; The host to connect to
-hostname = tip-wlan-cassandra-headless
+hostname = {{ include "cassandra.service" . }}
 
 ;; The port to connect to (9042 is the native protocol default)
 port = 9042

--- a/tip-wlan/charts/wlan-ssc-service/templates/configmap.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/configmap.yaml
@@ -29,5 +29,5 @@ data:
         }
     }
 
-  cqlshrc.tip-wlan: >-
+  cqlshrc.tip-wlan: |
   {{ tpl (.Files.Get "files/cqlshrc.tip-wlan") . | nindent 4 }}

--- a/tip-wlan/charts/wlan-ssc-service/templates/configmap.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
   cassandra-application.conf: >-
     datastax-java-driver {
         basic {
-            contact-points = [ "tip-wlan-cassandra-headless:9042" ]
+            contact-points = [ "{{ include "cassandra.service" . }}:9042" ]
             load-balancing-policy.local-datacenter = datacenter1
             session-keyspace = tip_wlan_keyspace
         }
@@ -28,3 +28,6 @@ data:
             password = {{ .Values.creds.cassandra.tip_password }}
         }
     }
+
+  cqlshrc.tip-wlan: >-
+  {{ tpl (.Files.Get "files/cqlshrc.tip-wlan") . | nindent 4 }}


### PR DESCRIPTION
To be able to deploy multiple instances of the wlan-ssc-service we have to pass it the calculated value of the Cassandra headless service instead of using a hardcoded string.