### PR TITLE
WIFI-1238 set all imagePullPolicies to Always

### DIFF
--- a/tip-wlan/charts/cassandra/templates/tests/test-cassandra-record-insert-del.yaml
+++ b/tip-wlan/charts/cassandra/templates/tests/test-cassandra-record-insert-del.yaml
@@ -12,6 +12,7 @@ spec:
   containers:
   - name: {{ include "common.name" . }}-test-cassandra-basic
     image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+    imagePullPolicy: Always
     command:
     - sh
     - -c

--- a/tip-wlan/charts/cassandra/templates/tests/test-cassandra-record-insert-del.yaml
+++ b/tip-wlan/charts/cassandra/templates/tests/test-cassandra-record-insert-del.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
   - name: {{ include "common.name" . }}-test-cassandra-basic
     image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
-    imagePullPolicy: Always
+    imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.pullPolicy }} 
     command:
     - sh
     - -c

--- a/tip-wlan/charts/cassandra/values.yaml
+++ b/tip-wlan/charts/cassandra/values.yaml
@@ -22,7 +22,7 @@ image:
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -297,7 +297,7 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
     repository: bitnami/cassandra-exporter
     tag: 2.3.4-debian-10-r119
     ## Optionally specify an array of imagePullSecrets.

--- a/tip-wlan/charts/kafka/templates/job-config.yaml
+++ b/tip-wlan/charts/kafka/templates/job-config.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: {{ include "common.fullname" . }}-config
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.pullPolicy }}
           command: ["/usr/local/script/runtimeConfig.sh"]
           volumeMounts:
             - name: config-volume

--- a/tip-wlan/charts/kafka/templates/job-config.yaml
+++ b/tip-wlan/charts/kafka/templates/job-config.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
         - name: {{ include "common.fullname" . }}-config
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          imagePullPolicy: Always
           command: ["/usr/local/script/runtimeConfig.sh"]
           volumeMounts:
             - name: config-volume

--- a/tip-wlan/charts/kafka/templates/tests/test-topic-create-produce-consume.yaml
+++ b/tip-wlan/charts/kafka/templates/tests/test-topic-create-produce-consume.yaml
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: {{ include "common.name" . }}-test-consume
     image: {{ .Values.image }}:{{ .Values.imageTag }}
-    imagePullPolicy: Always
+    imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.pullPolicy }} 
     command:
     - sh
     - -c

--- a/tip-wlan/charts/kafka/templates/tests/test-topic-create-produce-consume.yaml
+++ b/tip-wlan/charts/kafka/templates/tests/test-topic-create-produce-consume.yaml
@@ -10,6 +10,7 @@ spec:
   containers:
   - name: {{ include "common.name" . }}-test-consume
     image: {{ .Values.image }}:{{ .Values.imageTag }}
+    imagePullPolicy: Always
     command:
     - sh
     - -c

--- a/tip-wlan/charts/kafka/values.yaml
+++ b/tip-wlan/charts/kafka/values.yaml
@@ -15,7 +15,7 @@ imageTag: "5.0.1"  # Confluent image for Kafka 2.0.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-imagePullPolicy: "IfNotPresent"
+imagePullPolicy: "Always"
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/tip-wlan/charts/nginx-ingress-controller/values.yaml
+++ b/tip-wlan/charts/nginx-ingress-controller/values.yaml
@@ -40,7 +40,7 @@ controller:
     tag: "1.7.0"
 
     ## The pull policy for the Ingress controller image.
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   config:
     ## The name of the ConfigMap used by the Ingress controller.

--- a/tip-wlan/charts/opensync-gw-cloud/templates/deployment.yaml
+++ b/tip-wlan/charts/opensync-gw-cloud/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.global.integratedDeployment }}
         - name: {{ include "common.name" . }}-readiness-int-cloud
           image: alpine
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh
           - -c
@@ -71,7 +71,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           {{- if .Values.probes.enabled }}
           livenessProbe:
             tcpSocket:

--- a/tip-wlan/charts/opensync-gw-static/templates/deployment.yaml
+++ b/tip-wlan/charts/opensync-gw-static/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           {{- if .Values.probes.enabled }}
           livenessProbe:
             tcpSocket:

--- a/tip-wlan/charts/opensync-mqtt-broker/templates/statefulset.yaml
+++ b/tip-wlan/charts/opensync-mqtt-broker/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: {{ include "common.name" . }}-init-dir-ownership-change
-          image: alpine:3.6
+          image: {{ .Values.alpine.image }} 
           imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           # Change ownership to `mosquitto` user for a mounted volume
           command:

--- a/tip-wlan/charts/opensync-mqtt-broker/templates/statefulset.yaml
+++ b/tip-wlan/charts/opensync-mqtt-broker/templates/statefulset.yaml
@@ -46,6 +46,7 @@ spec:
       initContainers:
         - name: {{ include "common.name" . }}-init-dir-ownership-change
           image: alpine:3.6
+          imagePullPolicy: Always
           # Change ownership to `mosquitto` user for a mounted volume
           command:
           - sh

--- a/tip-wlan/charts/opensync-mqtt-broker/templates/statefulset.yaml
+++ b/tip-wlan/charts/opensync-mqtt-broker/templates/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       initContainers:
         - name: {{ include "common.name" . }}-init-dir-ownership-change
           image: alpine:3.6
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           # Change ownership to `mosquitto` user for a mounted volume
           command:
           - sh
@@ -64,7 +64,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.image.name }}:{{ .Values.image.tag }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           {{- if .Values.probes.enabled }}
           livenessProbe:
             tcpSocket:

--- a/tip-wlan/charts/opensync-mqtt-broker/values.yaml
+++ b/tip-wlan/charts/opensync-mqtt-broker/values.yaml
@@ -8,6 +8,9 @@ image:
   name: eclipse-mosquitto
   tag: latest
 
+alpine:
+  image: alpine:3.6
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/tip-wlan/charts/postgresql/templates/tests/test-postgres-record-insert-del.yaml
+++ b/tip-wlan/charts/postgresql/templates/tests/test-postgres-record-insert-del.yaml
@@ -12,6 +12,7 @@ spec:
   containers:
   - name: {{ include "common.name" . }}-test-postgres-basic
     image: {{ template "postgresql.image" . }}
+    imagePullPolicy: Always
     env:
       - name: POSTGRES_USER
         value: {{ include "postgresql.username" . | quote }}

--- a/tip-wlan/charts/postgresql/templates/tests/test-postgres-record-insert-del.yaml
+++ b/tip-wlan/charts/postgresql/templates/tests/test-postgres-record-insert-del.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
   - name: {{ include "common.name" . }}-test-postgres-basic
     image: {{ template "postgresql.image" . }}
-    imagePullPolicy: Always
+    imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.pullPolicy }} 
     env:
       - name: POSTGRES_USER
         value: {{ include "postgresql.username" . | quote }}

--- a/tip-wlan/charts/postgresql/values.yaml
+++ b/tip-wlan/charts/postgresql/values.yaml
@@ -22,7 +22,7 @@ image:
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/tip-wlan/charts/wlan-cloud-static-portal/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-cloud-static-portal/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} :
           env:
           - name: API
             value: {{ .Values.env.graphql }}

--- a/tip-wlan/charts/wlan-cloud-static-portal/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-cloud-static-portal/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} :
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }}
           env:
           - name: API
             value: {{ .Values.env.graphql }}

--- a/tip-wlan/charts/wlan-integrated-cloud-component-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-integrated-cloud-component-service/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       initContainers:
         - name: {{ include "common.name" . }}-readiness
           image: busybox:1.28
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command: ['sh', '-c', "until nslookup {{ $pg }}.{{ $ns }}.svc.cluster.local; do echo waiting for POSTGRES; sleep 2; done"]
         - name: {{ include "common.name" . }}-create-db-schema
           env:
@@ -49,7 +49,7 @@ spec:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
           image: postgres:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh
           - -c
@@ -86,7 +86,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           env:
             - name: BACKEND_SERVER
               value: {{ .Release.Name }}-{{ .Chart.Name }}

--- a/tip-wlan/charts/wlan-port-forwarding-gateway-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-port-forwarding-gateway-service/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       initContainers:
         - name: {{ include "common.name" . }}-readiness-opensync-gw
           image: alpine
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh
           - -c
@@ -57,7 +57,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           env:
             {{- include "common.env" . | nindent 12 }}
             - name: PF_GATEWAY_RELEASE_URL

--- a/tip-wlan/charts/wlan-portal-service/templates/statefulset.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           env:
             {{- include "common.env" . | nindent 12 }}
             - name: FILE_STORE_DIRECTORY_INTERNAL

--- a/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
           image: postgres:latest
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh
           - -c
@@ -123,7 +123,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           env:
             {{- include "common.env" . | nindent 12 }}
             - name: tip_wlan_AsyncExecutor_CorePoolSize

--- a/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
           image: postgres:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
           - sh
           - -c

--- a/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-prov-service/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               secretKeyRef:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
-          image: postgres:latest
+          image: {{ .Values.postgresql.image }}
           imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh

--- a/tip-wlan/charts/wlan-prov-service/values.yaml
+++ b/tip-wlan/charts/wlan-prov-service/values.yaml
@@ -144,6 +144,7 @@ affinity: {}
 
 postgresql:
   url: postgresql
+  image: postgres:latest
 
 env:
   protocol: https

--- a/tip-wlan/charts/wlan-spc-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-spc-service/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           env:
             {{- include "common.env" . | nindent 12 }}
             - name: tip.wlan.kafka.bootstrapServers

--- a/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
           image: cassandra:3.11.6
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh
           - -c
@@ -117,7 +117,7 @@ spec:
           {{- else }}
           image: {{ .Values.global.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           env:
             {{- include "common.env" . | nindent 12 }}
             - name: tip.wlan.kafka.bootstrapServers

--- a/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               secretKeyRef:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
-          image: cassandra:3.11.6
+          image: {{ .Values.cassandra.image }}
           imagePullPolicy: {{ .Values.pullPolicy | default .Values.global.pullPolicy }} 
           command:
           - sh

--- a/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                 name: {{ include "common.fullname" . }}-creds
                 key: schema-repo-password
           image: cassandra:3.11.6
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
           - sh
           - -c

--- a/tip-wlan/charts/wlan-ssc-service/values.yaml
+++ b/tip-wlan/charts/wlan-ssc-service/values.yaml
@@ -136,6 +136,7 @@ kafka:
 cassandra:
   url: cassandra-headless
   port: 9042
+  image: cassandra:3.11.6
 
 env:
   protocol: https

--- a/tip-wlan/charts/zookeeper/templates/statefulset.yaml
+++ b/tip-wlan/charts/zookeeper/templates/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: zookeeper
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.pullPolicy }} 
         {{- with .Values.command }}
           command: {{ range . }}
              - {{ . | quote }}

--- a/tip-wlan/charts/zookeeper/values.yaml
+++ b/tip-wlan/charts/zookeeper/values.yaml
@@ -18,7 +18,7 @@ updateStrategy:
 image:
   repository: zookeeper     # Container image repository for zookeeper container.
   tag: 3.5.5                # Container image tag for zookeeper container.
-  pullPolicy: IfNotPresent  # Image pull criteria for zookeeper container.
+  pullPolicy: Always        # Image pull criteria for zookeeper container.
 
 service:
   type: ClusterIP  # Exposes zookeeper on a cluster-internal IP.


### PR DESCRIPTION
To improve the kube-score result we should set all of our image pull policies to Always.