### PR TITLE
add prototype of workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,7 +71,7 @@ jobs:
         # helm dependency update
         # helm upgrade --install tip-wlan . -f resources/environments/aws-cicd.yaml --create-namespace --namespace ${GITHUB_REF##*/} 
         # using a timeout of 20 minutes as the EKS nodes may need to be scaled which takes some time
-        helm upgrade --install tip-wlan-pr-${{ env.PR_NUMBER }} wlan-cloud-helm/tip-wlan -f pr-deployment.yaml --namespace default --wait --timeout 20m --dry-run
+        helm upgrade --install tip-wlan-pr-${{ env.PR_NUMBER }} wlan-cloud-helm/tip-wlan -f pr-deployment.yaml --namespace default --wait --timeout 20m
 
   test:
     runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
 
     - name: Delete Cloud SDK Helm release
       run: |
-        helm delete tip-wlan-pr-${{ env.PR_NUMBER }} --namespace default --dry-run || true
+        helm delete tip-wlan-pr-${{ env.PR_NUMBER }} --namespace default || true
 
     - name: Delete namespace
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,16 +2,12 @@ name: CloudSDK deployment and testing
 
 env:
   PR_NUMBER: ${{ github.event.number }}
-  # AWS credentials
   AWS_EKS_NAME: tip-wlan-main
   AWS_DEFAULT_OUTPUT: json
   AWS_DEFAULT_REGION: us-east-2
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  # Cloud SDK certs
-  # CACERT: ${{ secrets.CACERT }}
-  # CAKEY: ${{ secrets.CAKEY }}
 
 on:
   pull_request:
@@ -41,18 +37,10 @@ jobs:
         path: Toolsmith
         repository: Telecominfraproject/Toolsmith
         token: ${{ secrets.PAT_TOKEN }}
-        ref: second-cloudsdk-instance-config
+        ref: WIFI-1245-add-template-for-pr-deployment
 
     - name: Generate Helm values file
       run: |
-        #mkdir ./wlan-helm/tip-wlan/resources/certs
-        #mkdir -p ./wlan-pki/testCA/private
-        #mkdir -p ./wlan-pki/testCA/newcerts
-        #mkdir -p ./wlan-pki/generated
-        #touch ./wlan-pki/testCA/index.txt
-        #echo "01" > ./wlan-pki/testCA/serial.txt
-        #echo "${{ env.CACERT }}" | base64 -d > ./wlan-pki/testCA/cacert.pem
-        #echo "${{ env.CAKEY }}" | base64 -d > ./wlan-pki/testCA/private/cakey.pem
         ./Toolsmith/helm-values/aws-cicd-pr-deployment.yaml.sh ${{ env.PR_NUMBER }} > pr-deployment.yaml
 
     - name: Generate certs
@@ -67,9 +55,6 @@ jobs:
 
     - name: Deploy Cloud SDK
       run: |
-        # the 2 lines below are needed for the new flow only, not needed for the old one
-        # helm dependency update
-        # helm upgrade --install tip-wlan . -f resources/environments/aws-cicd.yaml --create-namespace --namespace ${GITHUB_REF##*/} 
         # using a timeout of 20 minutes as the EKS nodes may need to be scaled which takes some time
         helm upgrade --install tip-wlan-pr-${{ env.PR_NUMBER }} wlan-cloud-helm/tip-wlan -f pr-deployment.yaml --namespace default --wait --timeout 20m
 
@@ -77,14 +62,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ deploy ]
     steps:
-    - name: Get kubeconfig for EKS ${{ env.AWS_EKS_NAME }}
-      run: |
-        aws eks update-kubeconfig --name ${{ env.AWS_EKS_NAME }}
-
     - name: Execute tests
       run: |
         echo Running tests...
-        sleep 5
+        # this is needed to make until work
+        set +e
+
+        urls="https://wlan-ui-pr-$PR_NUMBER.cicd.lab.wlan.tip.build https://wlan-graphql-pr-$PR_NUMBER.cicd.lab.wlan.tip.build/graphql"
+        for url in $urls; do
+          max_retry=300
+          counter=0
+          until curl --silent $url > /dev/null
+          do
+             sleep 1
+             [[ counter -eq $max_retry ]] && echo "$url not reachable after $counter tries...giving up" && exit 1
+             echo "#$counter: $url not reachable. trying again..."
+             ((counter++))
+          done
+          echo Successfully reached URL $url
+        done
+
         echo Tests were successful
 
   cleanup:
@@ -103,4 +100,3 @@ jobs:
     - name: Delete namespace
       run: |
         kubectl delete ns tip-pr-${{ env.PR_NUMBER }} --wait=true --ignore-not-found true
-

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,18 +41,19 @@ jobs:
         path: Toolsmith
         repository: Telecominfraproject/Toolsmith
         token: ${{ secrets.PAT_TOKEN }}
+        ref: second-cloudsdk-instance-config
 
-    #- name: Prepare environment
-    #  run: |
-    #     mkdir ./wlan-helm/tip-wlan/resources/certs
-    #     mkdir -p ./wlan-pki/testCA/private
-    #     mkdir -p ./wlan-pki/testCA/newcerts
-    #     mkdir -p ./wlan-pki/generated
-    #     touch ./wlan-pki/testCA/index.txt
-    #     echo "01" > ./wlan-pki/testCA/serial.txt
-    #     echo "${{ env.CACERT }}" | base64 -d > ./wlan-pki/testCA/cacert.pem
-    #     echo "${{ env.CAKEY }}" | base64 -d > ./wlan-pki/testCA/private/cakey.pem
-    #    cp ./Toolsmith/helm-values/aws-cicd.yaml ./wlan-helm/tip-wlan/resources/environments/aws-cicd.yaml
+    - name: Generate Helm values file
+      run: |
+        #mkdir ./wlan-helm/tip-wlan/resources/certs
+        #mkdir -p ./wlan-pki/testCA/private
+        #mkdir -p ./wlan-pki/testCA/newcerts
+        #mkdir -p ./wlan-pki/generated
+        #touch ./wlan-pki/testCA/index.txt
+        #echo "01" > ./wlan-pki/testCA/serial.txt
+        #echo "${{ env.CACERT }}" | base64 -d > ./wlan-pki/testCA/cacert.pem
+        #echo "${{ env.CAKEY }}" | base64 -d > ./wlan-pki/testCA/private/cakey.pem
+        ./Toolsmith/helm-values/aws-cicd-pr-deployment.yaml.sh ${{ env.PR_NUMBER }} > pr-deployment.yaml
 
     - name: Generate certs
       working-directory: wlan-pki-cert-scripts
@@ -70,7 +71,7 @@ jobs:
         # helm dependency update
         # helm upgrade --install tip-wlan . -f resources/environments/aws-cicd.yaml --create-namespace --namespace ${GITHUB_REF##*/} 
         # using a timeout of 20 minutes as the EKS nodes may need to be scaled which takes some time
-        helm upgrade --install tip-wlan-pr-${{ env.PR_NUMBER }} wlan-cloud-helm/tip-wlan -f Toolsmith/helm-values/aws-cicd.yaml --namespace default --wait --timeout 20m --dry-run --set global.nsPrefix=tip-pr-${{ env.PR_NUMBER }}
+        helm upgrade --install tip-wlan-pr-${{ env.PR_NUMBER }} wlan-cloud-helm/tip-wlan -f pr-deployment.yaml --namespace default --wait --timeout 20m --dry-run
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,105 @@
+name: CloudSDK deployment and testing
+
+env:
+  PR_NUMBER: ${{ github.event.number }}
+  # AWS credentials
+  AWS_EKS_NAME: tip-wlan-main
+  AWS_DEFAULT_OUTPUT: json
+  AWS_DEFAULT_REGION: us-east-2
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # Cloud SDK certs
+  # CACERT: ${{ secrets.CACERT }}
+  # CAKEY: ${{ secrets.CAKEY }}
+
+on:
+  pull_request:
+     branches: [ master ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout required repos
+      uses: actions/checkout@v2
+      with:
+        path: wlan-pki-cert-scripts
+        repository: Telecominfraproject/wlan-pki-cert-scripts
+    - name: Checkout Cloud SDK repo
+      uses: actions/checkout@v2
+      with:
+        path: wlan-cloud-helm
+        repository: Telecominfraproject/wlan-cloud-helm
+    - name: Checkout helm values repo
+      uses: actions/checkout@v2
+      with:
+        path: Toolsmith
+        repository: Telecominfraproject/Toolsmith
+        token: ${{ secrets.PAT_TOKEN }}
+
+    #- name: Prepare environment
+    #  run: |
+    #     mkdir ./wlan-helm/tip-wlan/resources/certs
+    #     mkdir -p ./wlan-pki/testCA/private
+    #     mkdir -p ./wlan-pki/testCA/newcerts
+    #     mkdir -p ./wlan-pki/generated
+    #     touch ./wlan-pki/testCA/index.txt
+    #     echo "01" > ./wlan-pki/testCA/serial.txt
+    #     echo "${{ env.CACERT }}" | base64 -d > ./wlan-pki/testCA/cacert.pem
+    #     echo "${{ env.CAKEY }}" | base64 -d > ./wlan-pki/testCA/private/cakey.pem
+    #    cp ./Toolsmith/helm-values/aws-cicd.yaml ./wlan-helm/tip-wlan/resources/environments/aws-cicd.yaml
+
+    - name: Generate certs
+      working-directory: wlan-pki-cert-scripts
+      run: |
+        ./generate_all.sh
+        ./copy-certs-to-helm.sh ../wlan-cloud-helm
+
+    - name: Get kubeconfig for EKS ${{ env.AWS_EKS_NAME }}
+      run: |
+        aws eks update-kubeconfig --name ${{ env.AWS_EKS_NAME }}
+
+    - name: Deploy Cloud SDK
+      run: |
+        # the 2 lines below are needed for the new flow only, not needed for the old one
+        # helm dependency update
+        # helm upgrade --install tip-wlan . -f resources/environments/aws-cicd.yaml --create-namespace --namespace ${GITHUB_REF##*/} 
+        # using a timeout of 20 minutes as the EKS nodes may need to be scaled which takes some time
+        helm upgrade --install tip-wlan-pr-${{ env.PR_NUMBER }} wlan-cloud-helm/tip-wlan -f Toolsmith/helm-values/aws-cicd.yaml --namespace default --wait --timeout 20m --dry-run --set global.nsPrefix=tip-pr-${{ env.PR_NUMBER }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [ deploy ]
+    steps:
+    - name: Get kubeconfig for EKS ${{ env.AWS_EKS_NAME }}
+      run: |
+        aws eks update-kubeconfig --name ${{ env.AWS_EKS_NAME }}
+
+    - name: Execute tests
+      run: |
+        echo Running tests...
+        sleep 5
+        echo Tests were successful
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: [ deploy, test ]
+    if: ${{ always() }}
+    steps:
+    - name: Get kubeconfig for EKS ${{ env.AWS_EKS_NAME }}
+      run: |
+        aws eks update-kubeconfig --name ${{ env.AWS_EKS_NAME }}
+
+    - name: Delete Cloud SDK Helm release
+      run: |
+        helm delete tip-wlan-pr-${{ env.PR_NUMBER }} --namespace default --dry-run || true
+
+    - name: Delete namespace
+      run: |
+        kubectl delete ns tip-pr-${{ env.PR_NUMBER }} --wait=true --ignore-not-found true
+


### PR DESCRIPTION
## known issues
* node port prefixes are hardcoded which will result in conflicts on multiple runs for different PRs
* parallel workflow executions are possible which may result in conflicts, Github does not allow to prevent this
* load balancer logging to S3 is not configured, do we need this for PR deployments?
* debug ports for APs are disabled, will be enabled as soon as #34 is merged
* global image pull policy has been set to IfNotPresent to prevent running into rate limits of Docker registry 
