### PR TITLE
Integrate enforce Jira issue key workflow

### DIFF
--- a/.github/workflows/enforce-jira-issue-key.yml
+++ b/.github/workflows/enforce-jira-issue-key.yml
@@ -1,0 +1,37 @@
+name: Ensure Jira issue is linked
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check_for_issue_key:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log into Jira
+        uses: atlassian/gajira-login@v2.0.0
+        env: 
+          JIRA_BASE_URL: ${{ secrets.TIP_JIRA_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.TIP_JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.TIP_JIRA_API_TOKEN }}
+      - name: Find issue key in PR title
+        id: issue_key_pr_title
+        continue-on-error: true
+        uses: atlassian/gajira-find-issue-key@v2.0.2
+        with:
+          string: ${{ github.event.pull_request.title }}
+          from: "" # required workaround for bug https://github.com/atlassian/gajira-find-issue-key/issues/24
+      - name: Find issue key in branch name
+        continue-on-error: true
+        id: issue_key_branch_name
+        uses: atlassian/gajira-find-issue-key@v2.0.2
+        with:
+          string: ${{ github.event.pull_request.head.ref }}
+          from: "" # required workaround for bug https://github.com/atlassian/gajira-find-issue-key/issues/24
+
+      - name: Check if issue key was found
+        run: |
+          if [[ -z "${{ steps.issue_key_pr_title.outputs.issue }}" && -z "${{ steps.issue_key_branch_name.outputs.issue }}" ]]; then
+             echo "Jira issue key could not be found!"
+             exit 1
+          fi


### PR DESCRIPTION
This PR will add enforce that Jira issue keys are given when creating a PR.