### PR TITLE
Wifi 1319 ssl issue

### DIFF
--- a/tip-wlan/charts/nginx-ingress-controller/templates/controller-configmap.yaml
+++ b/tip-wlan/charts/nginx-ingress-controller/templates/controller-configmap.yaml
@@ -8,3 +8,4 @@ metadata:
 data:
     external-status-address: {{ .Values.controller.config.externalStatusAddress }}
     client-max-body-size: {{ .Values.controller.config.clientMaxBodySize }}
+    error-log-level: {{ .Values.controller.config.errorLogLevel }}

--- a/tip-wlan/charts/nginx-ingress-controller/values.yaml
+++ b/tip-wlan/charts/nginx-ingress-controller/values.yaml
@@ -56,6 +56,8 @@ controller:
     ## Max message size coming from the Client
     clientMaxBodySize: "20m"
 
+    ## Error 
+    errorLogLevel: "error"
   ## It is recommended to use your own TLS certificates and keys
   defaultTLS:
     ## The base64-encoded TLS certificate for the default HTTPS server. If not specified, a pre-generated self-signed certificate is used.

--- a/tip-wlan/charts/wlan-portal-service/resources/config/logback.xml
+++ b/tip-wlan/charts/wlan-portal-service/resources/config/logback.xml
@@ -7,7 +7,7 @@
 <!-- For professional support please see                            -->
 <!--    http://www.qos.ch/shop/products/professionalSupport         -->
 <!--                                                                -->
-<configuration>
+<configuration scan="true" scanPeriod="30 seconds">
   <conversionRule conversionWord="filteredStack"
                   converterClass="com.telecominfraproject.wlan.server.exceptions.logback.ExceptionCompressingConverter" />
 

--- a/tip-wlan/charts/wlan-portal-service/resources/config/ssl.properties
+++ b/tip-wlan/charts/wlan-portal-service/resources/config/ssl.properties
@@ -1,0 +1,14 @@
+truststorePass={{ .Values.global.certificatePasswords.sslTruststore }}
+truststoreFile=file:///opt/tip-wlan/certs/truststore.jks
+truststoreType=JKS
+truststoreProvider=SUN
+
+keyAlias=1
+keystorePass={{ .Values.global.certificatePasswords.sslKeystore }}
+keystoreFile=file:///opt/tip-wlan/certs/server.pkcs12
+keystoreType=pkcs12
+keystoreProvider=SunJSSE
+
+sslProtocol=TLS
+sslEnabledProtocols=TLSv1.2,TLSv1.1,TLSv1
+sslCiphers=TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA

--- a/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.disableTLSv13.enabled }}
+{{- if not .Values.tlsv13.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
@@ -6,19 +6,5 @@ metadata:
   namespace: {{ include "common.namespace" . }}
 type: Opaque
 data:
-  ssl.properties: |-
-    truststorePass={{ .Values.global.certificatePasswords.sslTruststore }}
-    truststoreFile=file:///opt/tip-wlan/certs/truststore.jks
-    truststoreType=JKS
-    truststoreProvider=SUN
-
-    keyAlias=1
-    keystorePass={{ .Values.global.certificatePasswords.sslKeystore }}
-    keystoreFile=file:///opt/tip-wlan/certs/server.pkcs12
-    keystoreType=pkcs12
-    keystoreProvider=SunJSSE
-
-    sslProtocol=TLS
-    sslEnabledProtocols=TLSv1.2,TLSv1.1,TLSv1
-    sslCiphers=TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+  ssl.properties: {{ tpl ( .Files.Get "resources/config/ssl.properties" ) . | b64enc }}
 {{- end }}

--- a/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
@@ -7,7 +7,18 @@ metadata:
 type: Opaque
 data:
   ssl.properties: |-
-    {{ (.Files.Glob "resources/certs/ssl.properties").AsSecrets | indent 4 }}
+    truststorePass={{ .Values.global.certificatePasswords.sslTruststore }}
+    truststoreFile=file:///opt/tip-wlan/certs/truststore.jks
+    truststoreType=JKS
+    truststoreProvider=SUN
+
+    keyAlias=1
+    keystorePass={{ .Values.global.certificatePasswords.sslKeystore }}
+    keystoreFile=file:///opt/tip-wlan/certs/server.pkcs12
+    keystoreType=pkcs12
+    keystoreProvider=SunJSSE
+
+    sslProtocol=TLS
     sslEnabledProtocols=TLSv1.2,TLSv1.1,TLSv1
     sslCiphers=TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA
 {{- end }}

--- a/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.disableTLSv13.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.fullname" . }}-ssl-config
+  namespace: {{ include "common.namespace" . }}
+type: Opaque
+data:
+  ssl.properties: |-
+    {{ (.Files.Glob "resources/certs/ssl.properties").AsSecrets | indent 4 }}
+    sslEnabledProtocols=TLSv1.2,TLSv1.1,TLSv1
+    sslCiphers=TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+{{- end }}

--- a/tip-wlan/charts/wlan-portal-service/templates/statefulset.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/statefulset.yaml
@@ -115,7 +115,7 @@ spec:
             subPath: server.pkcs12
           - mountPath: /app/portal/log
             name: logback-config
-          {{- if .Values.disableTLSv13.enabled }}
+          {{- if not .Values.tlsv13.enabled }}
           - mountPath: /app/portal/certs
             name: ssl-config
           {{- end }}
@@ -158,7 +158,7 @@ spec:
       - name: logback-config
         configMap:
             name: {{ include "common.fullname" . }}-log-config
-      {{- if .Values.disableTLSv13.enabled }}
+      {{- if not .Values.tlsv13.enabled }}
       - name: ssl-config
         secret:
           secretName: {{ include "common.fullname" . }}-ssl-config

--- a/tip-wlan/charts/wlan-portal-service/templates/statefulset.yaml
+++ b/tip-wlan/charts/wlan-portal-service/templates/statefulset.yaml
@@ -113,9 +113,12 @@ spec:
           - mountPath: /opt/tip-wlan/certs/server.pkcs12
             name: certificates
             subPath: server.pkcs12
-          - mountPath: /app/portal/logback.xml
+          - mountPath: /app/portal/log
             name: logback-config
-            subPath: logback.xml
+          {{- if .Values.disableTLSv13.enabled }}
+          - mountPath: /app/portal/certs
+            name: ssl-config
+          {{- end }}
           - mountPath: {{ $file_store_path }}
             name: file-store-data
           {{- include "jmxPrometheus.configVolumeMount" . | nindent 10 }}
@@ -155,6 +158,11 @@ spec:
       - name: logback-config
         configMap:
             name: {{ include "common.fullname" . }}-log-config
+      {{- if .Values.disableTLSv13.enabled }}
+      - name: ssl-config
+        secret:
+          secretName: {{ include "common.fullname" . }}-ssl-config
+      {{- end }}
       {{- if not .Values.persistence.enabled }}
       - name: file-store-data
         emptyDir: {}

--- a/tip-wlan/charts/wlan-portal-service/values.yaml
+++ b/tip-wlan/charts/wlan-portal-service/values.yaml
@@ -153,3 +153,6 @@ env:
 # on the PV
 filestore:
   internal: "/tmp/filestore"
+
+disableTLSv13:
+  enabled: false

--- a/tip-wlan/charts/wlan-portal-service/values.yaml
+++ b/tip-wlan/charts/wlan-portal-service/values.yaml
@@ -154,5 +154,5 @@ env:
 filestore:
   internal: "/tmp/filestore"
 
-disableTLSv13:
-  enabled: false
+tlsv13:
+  enabled: true

--- a/tip-wlan/charts/wlan-prov-service/values.yaml
+++ b/tip-wlan/charts/wlan-prov-service/values.yaml
@@ -128,7 +128,7 @@ affinity: {}
 
 postgresql:
   url: postgresql
-  image: postgres:latest
+  image: postgres:11
 
 env:
   protocol: https

--- a/tip-wlan/example-values/microk8s-basic/values.yaml
+++ b/tip-wlan/example-values/microk8s-basic/values.yaml
@@ -31,6 +31,8 @@ wlan-cloud-graphql-gw:
   enabled: true
   env:
     portalsvc: tip-wlan-wlan-portal-service:9051
+  service:
+    type: ClusterIP
   ingress:
     hosts:
       - host: wlan-ui-graphql.wlan.local
@@ -45,8 +47,6 @@ wlan-cloud-static-portal:
   enabled: true
   env:
     graphql: https://wlan-ui-graphql.wlan.local
-  service:
-    type: NodePort
   ingress:
     hosts:
       - host: wlan-ui.wlan.local
@@ -67,6 +67,8 @@ wlan-portal-service:
     type: LoadBalancer
     annotations:
       metallb.universe.tf/allow-shared-ip: default
+  disableTLSv13:
+    enabled: true
 
 wlan-prov-service:
   enabled: true

--- a/tip-wlan/example-values/microk8s-basic/values.yaml
+++ b/tip-wlan/example-values/microk8s-basic/values.yaml
@@ -67,8 +67,8 @@ wlan-portal-service:
     type: LoadBalancer
     annotations:
       metallb.universe.tf/allow-shared-ip: default
-  disableTLSv13:
-    enabled: true
+  tlsv13:
+    enabled: false
 
 wlan-prov-service:
   enabled: true


### PR DESCRIPTION
Updated the following:
- Added ssl.properties with additional properties which would be used to disable TLSv1.3 in Portal Service, if required (currently only needed for microK8s env).
- Moved logback.xml to under /portal/log folder. This is needed to avoid restarting respective component service after editing configMap that contains logback.xml, since with this change logback.xml is not under subPath of the mountedVolume in the Helm chart. ConfigMap updates are not passed on [if mount is in subPath](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) 
- Updated NGINX configMap to enable logging, if needed.
- Updated Postgres image to a specific tag (in Provisioning initContainer) instead of latest. 
