### PR TITLE
fix prov service oom kills

### DIFF
--- a/tip-wlan/charts/wlan-prov-service/values.yaml
+++ b/tip-wlan/charts/wlan-prov-service/values.yaml
@@ -125,10 +125,10 @@ ingress:
 resources:
   limits:
     cpu: 500m
-    memory: 350Mi
+    memory: 600Mi
   requests:
     cpu: 10m
-    memory: 350Mi
+    memory: 600Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
Currently seeing these memory spikes for the prov service. That's why this adjustment is needed.
![image](https://user-images.githubusercontent.com/5527832/123420187-87455280-d5bb-11eb-8699-6fa457d62e0c.png)
